### PR TITLE
Use `IsDefined` to check the existence of attributes

### DIFF
--- a/src/ExtendedFluentValidation/Extensions.cs
+++ b/src/ExtendedFluentValidation/Extensions.cs
@@ -1,4 +1,4 @@
-﻿static class Extensions
+static class Extensions
 {
     const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic;
 
@@ -14,7 +14,7 @@
     }
 
     public static bool AllowsEmpty(this MemberInfo property) =>
-        property.GetCustomAttribute<AllowEmptyAttribute>() != null;
+        Attribute.IsDefined(property, typeof(AllowEmptyAttribute));
 
     public static List<PropertyInfo> GettableProperties<[DynamicMembers(DynamicTypes.PublicProperties | DynamicTypes.NonPublicProperties)] T>(IReadOnlyList<string>? exclusions)
     {
@@ -33,7 +33,7 @@
     }
 
     static bool IsCompilerGenerated(this PropertyInfo info) =>
-        info.GetCustomAttribute<CompilerGeneratedAttribute>() != null;
+        Attribute.IsDefined(info, typeof(CompilerGeneratedAttribute));
 
     public static bool IsString(this PropertyInfo property) =>
         property.PropertyType == typeof(string);


### PR DESCRIPTION
Micro benchmark of `GetCustomAttribute` vs `IsDefined`

| Method              | Mean     | Error   | StdDev  | Ratio | Gen0   | Allocated | Alloc Ratio |
|-------------------- |---------:|--------:|--------:|------:|-------:|----------:|------------:|
| GetCustomAttributes | 225.0 ns | 0.63 ns | 0.50 ns |  1.00 | 0.0124 |     104 B |        1.00 |
| GetCustomAttribute  | 217.6 ns | 0.85 ns | 0.79 ns |  0.97 | 0.0124 |     104 B |        1.00 |
| IsDefined           | 132.4 ns | 0.54 ns | 0.42 ns |  0.59 |      - |         - |        0.00 |

<details>
<summary>benchmark code</summary>

```cs
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Reflection;
using System.Runtime.CompilerServices;

BenchmarkRunner.Run<AttributeBenchmarks>();

[MemoryDiagnoser]
public class AttributeBenchmarks
{
    private MemberInfo _member;

    [GlobalSetup]
    public void Setup()
    {
        _member = typeof(MyClas).GetMember("MyProperty", BindingFlags.Public | BindingFlags.Instance)[0];
    }

    [Benchmark(Baseline = true)]
    public bool GetCustomAttributes() => _member.GetCustomAttributes<CompilerGeneratedAttribute>().Any();

    [Benchmark]
    public bool GetCustomAttribute() => _member.GetCustomAttribute<CompilerGeneratedAttribute>() != null;

    [Benchmark]
    public bool IsDefined() => Attribute.IsDefined(_member, typeof(CompilerGeneratedAttribute));
}

class MyClas
{
    [CompilerGenerated]
    public int MyProperty { get; set; }
}
```

</details>